### PR TITLE
Watch included templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 
 ## Installation
 `npm i parcel-plugin-nunjucks` or `yarn add parcel-plugin-nunjucks`
+
+Parcel will now render nunjucks template files with an `.njk` extension.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 
 ## Installation
 `npm i parcel-plugin-nunjucks` or `yarn add parcel-plugin-nunjucks`
+
+Parcel will now compile nunjucks template files with an `.njk` extension.

--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@
 
 ## Installation
 `npm i parcel-plugin-nunjucks` or `yarn add parcel-plugin-nunjucks`
-
-Parcel will now compile nunjucks template files with an `.njk` extension.

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "peerDependencies": {
     "nunjucks": "~3",
     "parcel-bundler": "~1"
+  },
+  "dependencies": {
+    "klaw-sync": "^3.0.2"
   }
 }

--- a/src/NunjucksAsset.js
+++ b/src/NunjucksAsset.js
@@ -15,11 +15,7 @@ class NunjucksAsset extends HTMLAsset {
   async getDependencies() {
     await super.getDependencies();
     // Walk nunjucks directory and add any templates to dependencies
-    const paths = klawSync(this.nunjucksDir, {
-      nodir: true,
-      noRecurseOnFailedFilter: true,
-      filter: d => !d.path.includes('node_modules'),
-    });
+    const paths = klawSync(this.nunjucksDir, { nodir: true });
     const filesList = paths.filter(p =>
       path.extname(p.path).toLowerCase() === '.njk');
     filesList.forEach(dep => {

--- a/src/NunjucksAsset.js
+++ b/src/NunjucksAsset.js
@@ -1,5 +1,6 @@
 const nunjucks = require('nunjucks');
 const path = require('path');
+const klawSync = require('klaw-sync');
 const HTMLAsset = require('parcel-bundler/src/assets/HTMLAsset');
 
 class NunjucksAsset extends HTMLAsset {
@@ -8,6 +9,18 @@ class NunjucksAsset extends HTMLAsset {
 
     // Set nunjucks to resolve paths relative to current asset's path
     nunjucks.configure(path.dirname(name));
+    this.nunjucksDir = path.dirname(name);
+  }
+
+  async getDependencies() {
+    await super.getDependencies();
+    // Walk nunjucks directory and add any templates to dependencies
+    const paths = klawSync(this.nunjucksDir, {nodir: true});
+    const filesList = paths.filter(p =>
+      path.extname(p.path).toLowerCase() === '.njk');
+    filesList.forEach(dep => {
+      this.addDependency(dep.path, { includedInParent: true });
+    });
   }
 
   parse(code) {

--- a/src/NunjucksAsset.js
+++ b/src/NunjucksAsset.js
@@ -15,7 +15,11 @@ class NunjucksAsset extends HTMLAsset {
   async getDependencies() {
     await super.getDependencies();
     // Walk nunjucks directory and add any templates to dependencies
-    const paths = klawSync(this.nunjucksDir, {nodir: true});
+    const paths = klawSync(this.nunjucksDir, {
+      nodir: true,
+      noRecurseOnFailedFilter: true,
+      filter: d => !d.path.includes('node_modules'),
+    });
     const filesList = paths.filter(p =>
       path.extname(p.path).toLowerCase() === '.njk');
     filesList.forEach(dep => {


### PR DESCRIPTION
Hey, great plugin!

Currently, parcel doesn't watch for changes in included nunjucks templates, i.e.:

```jinja
{% include "some/template.njk" %}
```

This change walks the directory of the base nunjucks file and adds any templates it finds with the `.njk` extension to parcel's dependencies.

This is basically so you get auto-reloading in parcel as you're editing templates...

Also added a quick line to the README that the plugin requires your nunjucks templates have extension `.njk`, which wasn't totally clear to me when I first installed the plugin.